### PR TITLE
Let `dest` be optional on the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ See the [GitHub API documentation for repositories](https://developer.github.com
 ## CLI
 
 ```sh
-$ repos <names> <dest>
+$ repos <names> [dest]
 ```
 
 * `names` - one or more comma-separated user names or orgs
-* `dest` - destination path to use, default is `repos.json`
+* `dest` - destination path for JSON file (optional)
 
 ## About
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,7 +6,10 @@ const write = require('write');
 
 repos(argv._[0].split(','), argv)
   .then(res => {
-    let filepath = argv._[1] || 'repos.json';
+    let filepath = argv._[1];
+    if (!filepath) {
+      return console.log(JSON.stringify(res, null, 2));
+    }
     write(filepath, JSON.stringify(res, null, 2), err => {
       if (err) {
         console.error(err);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,6 +4,10 @@ const repos = require('../');
 const argv = require('minimist')(process.argv.slice(2));
 const write = require('write');
 
+if (!argv.token && !(argv.username && argv.password)) {
+  argv.token = process.env.GITHUB_TOKEN;
+}
+
 repos(argv._[0].split(','), argv)
   .then(res => {
     let filepath = argv._[1];

--- a/test/support/auth.js
+++ b/test/support/auth.js
@@ -14,6 +14,9 @@ if (!auth) {
   } else {
     auth.username = argv.username || argv._[0] || process.env.GITHUB_USERNAME;
     auth.password = argv.password || argv._[1] || process.env.GITHUB_PASSWORD;
+    if (!auth.username || !auth.password) {
+      auth.token = process.env.GITHUB_TOKEN;
+    }
   }
 }
 


### PR DESCRIPTION
I would like to make `dest` optional, so I can pipe it without being forced to write a file.

I also tweaked the testing to accept `process.env.GITHUB_TOKEN`.